### PR TITLE
Add tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,7 @@ RUN apk add --update git \
                      postgresql-dev \
                      postgresql-client \
                      nodejs \
-                     file
+                     file \
+                     tzdata
 
 CMD [ "irb" ]


### PR DESCRIPTION
To fix issues like
```
13:50 $ docker-compose run web bundle exec rake db:setup
Starting billing_database_1 ... done
Starting billing_redis_1    ... done
Created database 'billing_dev'
Created database 'billing_test'
rake aborted!
TZInfo::DataSourceNotFound: tzinfo-data is not present. Please add gem 'tzinfo-data' to your Gemfile and run bundle install
/usr/local/bundle/gems/activesupport-5.1.5/lib/active_support/railtie.rb:22:in `rescue in block in <class:Railtie>'
/usr/local/bundle/gems/activesupport-5.1.5/lib/active_support/railtie.rb:19:in `block in <class:Railtie>'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/initializable.rb:30:in `instance_exec'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/initializable.rb:30:in `run'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/initializable.rb:59:in `block in run_initializers'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/initializable.rb:58:in `run_initializers'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/application.rb:353:in `initialize!'
/app/config/environment.rb:5:in `<top (required)>'
/usr/local/bundle/gems/skylight-core-2.0.2/lib/skylight/core/probes.rb:119:in `require'
/usr/local/bundle/gems/skylight-core-2.0.2/lib/skylight/core/probes.rb:119:in `require'
/usr/local/bundle/gems/activesupport-5.1.5/lib/active_support/dependencies.rb:292:in `block in require'
/usr/local/bundle/gems/activesupport-5.1.5/lib/active_support/dependencies.rb:258:in `load_dependency'
/usr/local/bundle/gems/activesupport-5.1.5/lib/active_support/dependencies.rb:292:in `require'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/application.rb:329:in `require_environment!'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/application.rb:445:in `block in run_tasks_blocks'
/usr/local/bundle/gems/bugsnag-6.8.0/lib/bugsnag/integrations/rake.rb:18:in `execute_with_bugsnag'
/usr/local/bundle/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'

Caused by:
TZInfo::ZoneinfoDirectoryNotFound: None of the paths included in TZInfo::ZoneinfoDataSource.search_path are valid zoneinfo directories.
/usr/local/bundle/gems/tzinfo-1.2.5/lib/tzinfo/zoneinfo_data_source.rb:180:in `initialize'
/usr/local/bundle/gems/tzinfo-1.2.5/lib/tzinfo/data_source.rb:180:in `new'
/usr/local/bundle/gems/tzinfo-1.2.5/lib/tzinfo/data_source.rb:180:in `create_default_data_source'
/usr/local/bundle/gems/tzinfo-1.2.5/lib/tzinfo/data_source.rb:40:in `block in get'
/usr/local/bundle/gems/tzinfo-1.2.5/lib/tzinfo/data_source.rb:39:in `synchronize'
/usr/local/bundle/gems/tzinfo-1.2.5/lib/tzinfo/data_source.rb:39:in `get'
/usr/local/bundle/gems/activesupport-5.1.5/lib/active_support/railtie.rb:20:in `block in <class:Railtie>'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/initializable.rb:30:in `instance_exec'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/initializable.rb:30:in `run'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/initializable.rb:59:in `block in run_initializers'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/initializable.rb:58:in `run_initializers'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/application.rb:353:in `initialize!'
/app/config/environment.rb:5:in `<top (required)>'
/usr/local/bundle/gems/skylight-core-2.0.2/lib/skylight/core/probes.rb:119:in `require'
/usr/local/bundle/gems/skylight-core-2.0.2/lib/skylight/core/probes.rb:119:in `require'
/usr/local/bundle/gems/activesupport-5.1.5/lib/active_support/dependencies.rb:292:in `block in require'
/usr/local/bundle/gems/activesupport-5.1.5/lib/active_support/dependencies.rb:258:in `load_dependency'
/usr/local/bundle/gems/activesupport-5.1.5/lib/active_support/dependencies.rb:292:in `require'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/application.rb:329:in `require_environment!'
/usr/local/bundle/gems/railties-5.1.5/lib/rails/application.rb:445:in `block in run_tasks_blocks'
/usr/local/bundle/gems/bugsnag-6.8.0/lib/bugsnag/integrations/rake.rb:18:in `execute_with_bugsnag'
/usr/local/bundle/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
```